### PR TITLE
Configure frontend for production deployment

### DIFF
--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:8080/api';
+const API_BASE_URL = process.env.REACT_APP_API_URL
+  ? `${process.env.REACT_APP_API_URL}/api`
+  : 'http://localhost:8080/api';
 
 // Create axios instance with default config
 const api = axios.create({


### PR DESCRIPTION
- Update API_BASE_URL to use REACT_APP_API_URL environment variable
- Fallback to localhost for development
- Ready for Render static site deployment with backend URL: https://spotify-clone-backend-crve.onrender.com